### PR TITLE
Add transform support for Enums and Constants, and extend

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,8 @@ import {
 } from '@creditkarma/thrift-parser'
 
 import {
+    transformConstants,
+    transformEnums,
     transformModule,
     transformServices,
     transformStructs,
@@ -37,6 +39,8 @@ export const transformDoc = (fileName: string) => (doc: ThriftDocument | ThriftE
         const transform: ThriftMarkdown = [
             transformModule(fileName, doc),
             transformTypeDefs(doc),
+            transformConstants(doc),
+            transformEnums(doc),         
             transformStructs(doc),
             transformServices(doc),
         ]

--- a/src/main/transforms.ts
+++ b/src/main/transforms.ts
@@ -3,10 +3,14 @@ import * as path from 'path'
 import {
     BaseType,
     BooleanLiteral,
+    Comment,
+    ConstDefinition,
     ConstList,
     ConstMap,
     ConstValue,
     DoubleConstant,
+    EnumDefinition,
+    EnumMember,
     ExponentialLiteral,
     FieldDefinition,
     FloatLiteral,
@@ -32,7 +36,12 @@ import {
 } from '@creditkarma/thrift-parser'
 
 import {
+    ConstantsMemberRow,
+    ConstantsSection,
     DocSection,
+    EnumDefinitionTable,
+    EnumMemberRow,
+    EnumSection,
     FunctionSection,
     IBlockQuote,
     IHeaderFour,
@@ -141,17 +150,37 @@ function constTransform<U>(
         case SyntaxType.ConstMap: return f(r as ConstMap)
         case SyntaxType.DoubleConstant: return g((r as DoubleConstant).value)
         case SyntaxType.IntConstant: return g((r as IntConstant).value)
+        case SyntaxType.StringLiteral: return g((r as LiteralValue))
         default: return z(r as Identifier)
     }
 }
 
+function getConstListMembers(fld: ConstList) {
+    return fld.elements.map((elem) => {
+        return (elem as StringLiteral).value
+    })
+}
+
 const transformConst = (fld: ConstValue) => constTransform(
     fld,
-    (e) => `list<${transformField(e)}>`,
+    (e) => `list<${getConstListMembers(e).toString()}>`,
     (f) => `map<${transformField(f)}>`,
     getLiteralVal,
     (z) => `[${z.value}](#${z.value})`,
 )
+
+function extractComments(entityComments: Comment[], useHTMLEntities: boolean) {
+    var codeComments = "";
+    entityComments.forEach(element => {
+        if(element.type == SyntaxType.CommentBlock) {
+            element.value.forEach(elementChild => {
+                codeComments += elementChild.trimLeft();
+            });
+        }
+        // ignore any IDL '#' comments: SyntaxType.CommentLine
+    });
+    return useHTMLEntities ? codeComments.replace(/[\n\r]/g, '<br/>') : codeComments;
+}
 
 const isSection = (filter: SectionType, stmt: ThriftStatement) => stmt.type === filter
 const cIsSection = (filter: SectionType) => (stmt: ThriftStatement) => isSection(filter, stmt)
@@ -174,19 +203,85 @@ export const transformTypeDefs = (ast: ThriftDocument): TypeDefSection => {
 }
 
 /**
+ * Constants Transformations
+ */
+ const constMemberRow = (def: ConstDefinition): ConstantsMemberRow => [
+    def.name.value,
+    transformField(def.fieldType),
+    def.comments ? extractComments(def.comments, true) : '',
+    constLiteralValues(def)
+]
+function constLiteralValues(def: ConstDefinition){
+    if (def.initializer.type == SyntaxType.ConstList || def.initializer.type == SyntaxType.ConstMap) {
+        return transformConst(def.initializer).toString();
+    }
+    else {
+        return getLiteralVal(def.initializer as LiteralValue)
+    } 
+}
+const constDefinitionTable = (constRows: ConstantsMemberRow[]): ITable => {
+    return {
+        table: {
+            headers: ['Constant', 'Type', 'Description', 'Value'],
+            rows: constRows
+        }
+    }
+}
+export const transformConstants = (ast: ThriftDocument): ConstantsSection => {
+    const isConstant = cIsSection(SyntaxType.ConstDefinition)
+    var constRows = ast.body.filter(isConstant).map((def) => constMemberRow(def as ConstDefinition))
+    return [
+        { h2: 'Constants' },
+        constDefinitionTable(constRows)
+    ]
+}
+
+/** 
+ * Enumeration Transformations
+ */
+const enumMemberRow = (mbr: EnumMember): EnumMemberRow => [
+    mbr.name.value,
+    mbr.comments ? extractComments(mbr.comments, true) : ''
+]
+const enumDefinitionTable = (def: EnumDefinition): EnumDefinitionTable => [{
+        h3: def.name.value,
+    }, {
+        code: {
+            content: def.comments ? extractComments(def.comments, false) : ''
+        }
+    }, {
+        table: {
+            headers: ['Named Constant', 'Description'],
+            rows: def.members.map(enumMemberRow),
+        },
+    },
+]
+export const transformEnums = (ast: ThriftDocument): EnumSection => {
+    const isEnumeration = cIsSection(SyntaxType.EnumDefinition)
+    return [
+        { h2: 'Enumerations' },
+        ast.body.filter(isEnumeration).map((def) => enumDefinitionTable(def as EnumDefinition)),
+    ]
+}
+
+/**
  * Structure Transformations
  */
 const structFieldRow = (fld: FieldDefinition): StructFieldRow => [
     fld.fieldID ? fld.fieldID.value : null,
     fld.name.value,
     transformField(fld.fieldType),
-    fld.comments.length ? fld.comments[0].value : '',
+    fld.comments ? extractComments(fld.comments, true) : '',
     fld.requiredness || '',
-    fld.defaultValue ? transformConst(fld.defaultValue) : '',
+    fld.defaultValue ? (fld.defaultValue.type == SyntaxType.StringLiteral ? fld.defaultValue.value : transformConst(fld.defaultValue)) : '',
 ]
 
 const structDefinitionTable = (def: StructDefinition): StructDefinitionTable => [{
         h3: def.name.value,
+    }, {
+        code: {
+                content: def.comments ? extractComments(def.comments, false) : ''
+        }
     }, {
         table: {
             headers: ['Key', 'Field', 'Type', 'Description', 'Required', 'Default value'],
@@ -248,5 +343,6 @@ export const transformModule = (fileName: string, ast: ThriftDocument): ModuleSe
     return [
         { h1: `${path.parse(fileName).base.split('.')[0]}` },
         ast.body.filter(isNamespaceDefinition).map((stmt) => namespaceDefinition(stmt as NamespaceDefinition)),
+        '[[_TOC_]]' // MD table of contents entity
     ]
 }

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -20,10 +20,11 @@ export interface IHeaderOne { h1: string }
 export interface IHeaderTwo { h2: string }
 export interface IHeaderThree { h3: string }
 export interface IBlockQuote { blockquote: string }
+export interface ICodeBlock { code: { content: string } }
 export interface ITable {
     table: {
         headers: string[],
-        rows: StructFieldRow[],
+        rows: StructFieldRow[] | EnumMemberRow[] | ConstantsMemberRow[],
     }
 }
 
@@ -36,7 +37,7 @@ FloatLiteral | ExponentialLiteral
 export type DocSection = NamespaceDefinition | ServiceDefinition
 
 export type SectionType = SyntaxType.NamespaceDefinition | SyntaxType.ServiceDefinition |
-SyntaxType.StructDefinition | SyntaxType.TypedefDefinition
+SyntaxType.StructDefinition | SyntaxType.TypedefDefinition | SyntaxType.EnumDefinition | SyntaxType.ConstDefinition
 
 /**
  * Transform Types
@@ -45,11 +46,13 @@ SyntaxType.StructDefinition | SyntaxType.TypedefDefinition
 export type ThriftMarkdown = [
     ModuleSection,
     TypeDefSection,
+    ConstantsSection,
+    EnumSection, 
     StructSection,
     ServiceSection
 ]
 
-export type ModuleSection = [IHeaderOne, IBlockQuote[]]
+export type ModuleSection = [IHeaderOne, IBlockQuote[], string]
 
 export type TypedDefinitionTable = [IHeaderThree, IBlockQuote]
 export type TypeDefSection = [IHeaderTwo, TypedDefinitionTable[]]
@@ -58,7 +61,7 @@ export type FunctionSection = [IHeaderFour, IBlockQuote]
 export type ServiceDefintionSection = [IHeaderThree, FunctionSection[]]
 export type ServiceSection = [IHeaderTwo, ServiceDefintionSection[]]
 
-export type StructDefinitionTable = [IHeaderThree, ITable]
+export type StructDefinitionTable = [IHeaderThree, ICodeBlock, ITable]
 export type StructSection = [IHeaderTwo, StructDefinitionTable[]]
 export type StructFieldRow = [
     number | null,
@@ -66,6 +69,22 @@ export type StructFieldRow = [
     string,
     string | string[],
     string | null,
+    string
+]
+
+export type EnumDefinitionTable = [IHeaderThree, ICodeBlock, ITable]
+export type EnumSection = [IHeaderTwo, EnumDefinitionTable[]]
+export type EnumMemberRow = [
+    string,
+    string | string[]
+]
+
+export type ConstantsSection = [IHeaderTwo, ConstantsDefinitionTable]
+export type ConstantsDefinitionTable = ITable
+export type ConstantsMemberRow = [
+    string,
+    string,
+    string | string[],
     string
 ]
 


### PR DESCRIPTION
1. Add transform output for Thrift Enums, in individual type tables.
2. Add transform output of Thrift Constants in single table format.
3. Since tables require new lines characters to be html entities, add support to replace these in type comment strings.
4. Add specific handler function to process all type comments
5. Allow data structures and constants to log their Default values as literal values (not transformed)
6. All type definition comments to be logged in an MD code block region to highlight these descriptions
7. Add an MD "Table of Contents" to the Module Transformation output
 